### PR TITLE
Fix signUp async block

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -11,6 +11,15 @@ interface AuthContextType {
   user: User | null;
   session: Session | null;
   loading: boolean;
+  signUp: (
+    email: string,
+    password: string,
+    userData?: any
+  ) => Promise<{ data: { session: Session | null }; error: any }>;
+  signIn: (
+    email: string,
+    password: string
+  ) => Promise<{ data: { session: Session | null }; error: any }>;
   signOut: () => Promise<void>;
 }
 
@@ -41,6 +50,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => subscription.unsubscribe();
   }, []);
 
+  const signUp = async (
+    email: string,
+    password: string,
+    userData?: any
+  ) => {
     const redirectUrl = `${window.location.origin}/`;
 
     const { data, error } = await supabase.auth.signUp({


### PR DESCRIPTION
## Summary
- restore missing `signUp` function in `useAuth` hook
- reintroduce context typings for `signUp` and `signIn`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68712d93d6f0832fbf5c93f3374c8129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sign-up and sign-in functionality to the authentication system, allowing users to create new accounts and log in using their email and password.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->