### PR TITLE
Fix navigation to agency-auth

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { Car, Menu, User } from "lucide-react";
+import { Link } from "react-router-dom";
 
 const Header = () => {
   return (
@@ -30,8 +31,8 @@ const Header = () => {
             <User className="h-4 w-4" />
             Sign In
           </Button>
-          <Button variant="hero" size="sm" onClick={() => window.location.href = '/agency-auth'}>
-            List Your Fleet
+          <Button variant="hero" size="sm" asChild>
+            <Link to="/agency-auth">List Your Fleet</Link>
           </Button>
           <Button variant="ghost" size="icon" className="md:hidden">
             <Menu className="h-4 w-4" />

--- a/src/components/VehicleList.tsx
+++ b/src/components/VehicleList.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 
-interface Vehicle {
+export interface Vehicle {
   id: string;
   make: string;
   model: string;

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -14,12 +14,12 @@ interface AuthContextType {
   signUp: (
     email: string,
     password: string,
-    userData?: any
-  ) => Promise<{ data: { session: Session | null }; error: any }>;
+    userData?: Record<string, unknown>
+  ) => Promise<{ data: { session: Session | null }; error: unknown }>;
   signIn: (
     email: string,
     password: string
-  ) => Promise<{ data: { session: Session | null }; error: any }>;
+  ) => Promise<{ data: { session: Session | null }; error: unknown }>;
   signOut: () => Promise<void>;
 }
 
@@ -53,7 +53,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const signUp = async (
     email: string,
     password: string,
-    userData?: any
+    userData?: Record<string, unknown>
   ) => {
     const redirectUrl = `${window.location.origin}/`;
 

--- a/src/pages/AgencyAuth.tsx
+++ b/src/pages/AgencyAuth.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { Car, Eye, EyeOff } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -15,9 +15,10 @@ const AgencyAuth = () => {
   const [companyName, setCompanyName] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [loading, setLoading] = useState(false);
-  
+
   const { signIn, signUp } = useAuth();
   const { toast } = useToast();
+  const navigate = useNavigate();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -44,7 +45,7 @@ const AgencyAuth = () => {
         });
       } else if (!isLogin) {
         if (session) {
-          window.location.href = '/dashboard';
+          navigate('/dashboard');
         } else {
           toast({
             title: "Success",
@@ -52,7 +53,7 @@ const AgencyAuth = () => {
           });
         }
       } else {
-        window.location.href = '/dashboard';
+        navigate('/dashboard');
       }
     } catch (error: unknown) {
       toast({

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,8 +4,9 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useAuth } from '@/hooks/useAuth';
 import { supabase } from '@/integrations/supabase/client';
-import VehicleList from '@/components/VehicleList';
+import VehicleList, { Vehicle } from '@/components/VehicleList';
 import AddVehicleDialog from '@/components/AddVehicleDialog';
+import { Navigate } from 'react-router-dom';
 
 interface Agency {
   id: string;
@@ -16,7 +17,7 @@ interface Agency {
 const Dashboard = () => {
   const { user, signOut } = useAuth();
   const [agency, setAgency] = useState<Agency | null>(null);
-  const [vehicles, setVehicles] = useState([]);
+  const [vehicles, setVehicles] = useState<Vehicle[]>([]);
   const [showAddVehicle, setShowAddVehicle] = useState(false);
   const [loading, setLoading] = useState(true);
 
@@ -68,8 +69,7 @@ const Dashboard = () => {
   };
 
   if (!user) {
-    window.location.href = '/agency-auth';
-    return null;
+    return <Navigate to="/agency-auth" replace />;
   }
 
   if (loading) {
@@ -132,7 +132,7 @@ const Dashboard = () => {
             <CardHeader className="pb-2">
               <CardDescription>Available Now</CardDescription>
               <CardTitle className="text-3xl">
-                {vehicles.filter((v: any) => v.is_available).length}
+                {vehicles.filter((v) => v.is_available).length}
               </CardTitle>
             </CardHeader>
           </Card>
@@ -141,8 +141,13 @@ const Dashboard = () => {
             <CardHeader className="pb-2">
               <CardDescription>Average Daily Rate</CardDescription>
               <CardTitle className="text-3xl">
-                ${vehicles.length > 0 
-                  ? Math.round(vehicles.reduce((sum: number, v: any) => sum + parseFloat(v.daily_rate), 0) / vehicles.length)
+                ${vehicles.length > 0
+                  ? Math.round(
+                      vehicles.reduce(
+                        (sum: number, v) => sum + parseFloat(v.daily_rate),
+                        0
+                      ) / vehicles.length
+                    )
                   : 0}
               </CardTitle>
             </CardHeader>


### PR DESCRIPTION
## Summary
- use React Router navigation to open `/agency-auth`
- navigate to dashboard after auth instead of full page reload
- export `Vehicle` interface for use in dashboard
- type vehicle state properly and avoid `any`
- fix linter complaints about explicit `any`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687131c2b340832fa4daad14fa91879e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Navigation between pages is now smoother and faster, using client-side routing instead of full page reloads.
  * Enhanced type safety in authentication and dashboard features, reducing potential errors and improving reliability.

* **Technical Enhancements**
  * Internal updates to type annotations and interface exports for better maintainability and code quality. No changes to visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->