### PR TITLE
Implement PHP currency and image upload

### DIFF
--- a/src/components/FeaturedVehicles.tsx
+++ b/src/components/FeaturedVehicles.tsx
@@ -90,7 +90,7 @@ const FeaturedVehicles = () => {
                   </div>
                   <div className="text-right">
                     <div className="text-2xl font-bold text-primary">
-                      ${vehicle.price}
+                      ₱{vehicle.price}
                     </div>
                     <div className="text-sm text-muted-foreground">per day</div>
                   </div>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -20,11 +20,10 @@ const HeroSection = () => {
         <div className="max-w-4xl mx-auto">
           <h1 className="text-4xl md:text-6xl font-bold text-foreground mb-6">
             Find Your Perfect
-            <span className="bg-gradient-primary bg-clip-text text-transparent"> Rental Car</span>
+            <span className="bg-gradient-primary bg-clip-text text-transparent"> Rental Car</span> in Davao Oriental
           </h1>
           <p className="text-xl text-muted-foreground mb-8 max-w-2xl mx-auto">
-            Connect with local rental agencies and discover the best vehicles at competitive rates. 
-            From economy to luxury, find exactly what you need.
+            Currently serving Davao Oriental. More locations coming soon.
           </p>
           
           <Card variant="elevated" className="max-w-4xl mx-auto p-6 bg-background/95 backdrop-blur">
@@ -33,8 +32,8 @@ const HeroSection = () => {
                 <label className="text-sm font-medium text-foreground">Location</label>
                 <div className="relative">
                   <MapPin className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
-                  <Input 
-                    placeholder="Enter city or location" 
+                  <Input
+                    placeholder="Davao Oriental"
                     className="pl-9"
                   />
                 </div>

--- a/src/components/VehicleList.tsx
+++ b/src/components/VehicleList.tsx
@@ -139,7 +139,7 @@ const VehicleList = ({ vehicles, onUpdate }: VehicleListProps) => {
                     
                     <div className="text-right">
                       <div className="text-2xl font-bold text-primary">
-                        ${vehicle.daily_rate}/day
+                        ₱{vehicle.daily_rate}/day
                       </div>
                     </div>
                   </div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -141,7 +141,8 @@ const Dashboard = () => {
             <CardHeader className="pb-2">
               <CardDescription>Average Daily Rate</CardDescription>
               <CardTitle className="text-3xl">
-                ${vehicles.length > 0
+                ₱{
+                  vehicles.length > 0
                   ? Math.round(
                       vehicles.reduce(
                         (sum: number, v) => sum + parseFloat(v.daily_rate),


### PR DESCRIPTION
## Summary
- update AddVehicleDialog to support car photo uploads with a 2MB limit
- display prices using the Philippine peso symbol
- mention Davao Oriental availability on the home page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6871a20bdbac832fa29f1a0c159842ad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for uploading vehicle images via file upload, with a 2MB file size limit and error notification for oversized files.

* **Enhancements**
  * Updated currency symbols across the app from "$" to "₱" for all vehicle rates and statistics.
  * Improved hero section messaging and location input to highlight service in Davao Oriental.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->