### PR TITLE
Add booking management pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,8 @@ import { AuthProvider } from "@/hooks/useAuth";
 import Index from "./pages/Index";
 import AgencyAuth from "./pages/AgencyAuth";
 import Dashboard from "./pages/Dashboard";
+import BookVehicle from "./pages/BookVehicle";
+import ManageBookings from "./pages/ManageBookings";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -22,6 +24,8 @@ const App = () => (
             <Route path="/" element={<Index />} />
             <Route path="/agency-auth" element={<AgencyAuth />} />
             <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/book/:vehicleId" element={<BookVehicle />} />
+            <Route path="/manage-bookings" element={<ManageBookings />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/components/EditVehicleDialog.tsx
+++ b/src/components/EditVehicleDialog.tsx
@@ -45,11 +45,11 @@ const EditVehicleDialog = ({ open, onOpenChange, vehicle, onVehicleUpdated }: Ed
         fuel_type: vehicle.fuel_type,
         seats: String(vehicle.seats),
         daily_rate: String(vehicle.daily_rate),
-        weekly_rate: (vehicle as any).weekly_rate ? String((vehicle as any).weekly_rate) : '',
-        monthly_rate: (vehicle as any).monthly_rate ? String((vehicle as any).monthly_rate) : '',
+        weekly_rate: vehicle.weekly_rate ? String(vehicle.weekly_rate) : '',
+        monthly_rate: vehicle.monthly_rate ? String(vehicle.monthly_rate) : '',
         image_url: vehicle.image_url || '',
-        license_plate: (vehicle as any).license_plate || '',
-        vin: (vehicle as any).vin || ''
+        license_plate: vehicle.license_plate || '',
+        vin: vehicle.vin || ''
       });
     }
   }, [vehicle]);

--- a/src/components/FeaturedVehicles.tsx
+++ b/src/components/FeaturedVehicles.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Link } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Star, MapPin, MessageCircle, Car } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -108,11 +109,12 @@ const FeaturedVehicles = () => {
 
                 <div className="flex gap-2">
                   <Button
+                    asChild
                     variant={vehicle.is_available ? "default" : "outline"}
                     className="flex-1"
                     disabled={!vehicle.is_available}
                   >
-                    {vehicle.is_available ? "View Details" : "Notify When Available"}
+                    <Link to={`/book/${vehicle.id}`}>{vehicle.is_available ? "Book Now" : "Notify When Available"}</Link>
                   </Button>
                   <Button variant="outline" size="icon">
                     <MessageCircle className="h-4 w-4" />

--- a/src/components/VehicleList.tsx
+++ b/src/components/VehicleList.tsx
@@ -19,6 +19,10 @@ export interface Vehicle {
   seats: number;
   transmission: string;
   fuel_type: string;
+  weekly_rate?: string | null;
+  monthly_rate?: string | null;
+  license_plate?: string | null;
+  vin?: string | null;
 }
 
 interface VehicleListProps {

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -136,6 +136,50 @@ export type Database = {
           },
         ]
       }
+      bookings: {
+        Row: {
+          id: string
+          vehicle_id: string
+          customer_name: string
+          customer_email: string
+          start_date: string
+          end_date: string
+          status: string
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          vehicle_id: string
+          customer_name: string
+          customer_email: string
+          start_date: string
+          end_date: string
+          status?: string
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          vehicle_id?: string
+          customer_name?: string
+          customer_email?: string
+          start_date?: string
+          end_date?: string
+          status?: string
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "bookings_vehicle_id_fkey"
+            columns: ["vehicle_id"]
+            isOneToOne: false
+            referencedRelation: "vehicles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
     }
     Views: {
       [_ in never]: never

--- a/src/pages/BookVehicle.tsx
+++ b/src/pages/BookVehicle.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { supabase } from '@/integrations/supabase/client';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { useToast } from '@/hooks/use-toast';
+import { Car } from 'lucide-react';
+
+interface Vehicle {
+  id: string;
+  make: string;
+  model: string;
+  year: number;
+  image_url: string | null;
+  daily_rate: number;
+}
+
+const BookVehicle = () => {
+  const { vehicleId } = useParams();
+  const [vehicle, setVehicle] = useState<Vehicle | null>(null);
+  const [form, setForm] = useState({
+    name: '',
+    email: '',
+    start: '',
+    end: ''
+  });
+  const [loading, setLoading] = useState(false);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    if (!vehicleId) return;
+    const load = async () => {
+      const { data } = await supabase
+        .from('vehicles')
+        .select('id, make, model, year, image_url, daily_rate')
+        .eq('id', vehicleId)
+        .single();
+      setVehicle(data as Vehicle | null);
+    };
+    load();
+  }, [vehicleId]);
+
+  const update = (field: string, value: string) => {
+    setForm((f) => ({ ...f, [field]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!vehicleId) return;
+    setLoading(true);
+    const { error } = await supabase.from('bookings').insert({
+      vehicle_id: vehicleId,
+      customer_name: form.name,
+      customer_email: form.email,
+      start_date: form.start,
+      end_date: form.end
+    });
+    if (error) {
+      toast({ title: 'Error', description: (error as Error).message, variant: 'destructive' });
+    } else {
+      toast({ title: 'Booked', description: 'Your booking was created.' });
+      setForm({ name: '', email: '', start: '', end: '' });
+    }
+    setLoading(false);
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4 bg-background">
+      <div className="w-full max-w-xl">
+        <Card>
+          <CardHeader>
+            <CardTitle>Book Vehicle</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {vehicle ? (
+              <div className="space-y-2">
+                <div className="flex gap-4 items-center">
+                  <div className="w-24 h-24 bg-muted rounded flex items-center justify-center">
+                    {vehicle.image_url ? (
+                      <img src={vehicle.image_url} alt="car" className="w-full h-full object-cover rounded" referrerPolicy="no-referrer" crossOrigin="anonymous" />
+                    ) : (
+                      <Car className="h-8 w-8 text-muted-foreground" />
+                    )}
+                  </div>
+                  <div>
+                    <h3 className="font-semibold text-lg">
+                      {vehicle.year} {vehicle.make} {vehicle.model}
+                    </h3>
+                    <p className="text-muted-foreground">₱{vehicle.daily_rate} per day</p>
+                  </div>
+                </div>
+                <form onSubmit={handleSubmit} className="space-y-4 mt-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="name">Full Name</Label>
+                    <Input id="name" value={form.name} onChange={(e) => update('name', e.target.value)} required />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="email">Email</Label>
+                    <Input id="email" type="email" value={form.email} onChange={(e) => update('email', e.target.value)} required />
+                  </div>
+                  <div className="grid grid-cols-2 gap-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="start">Start Date</Label>
+                      <Input id="start" type="date" value={form.start} onChange={(e) => update('start', e.target.value)} required />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="end">End Date</Label>
+                      <Input id="end" type="date" value={form.end} onChange={(e) => update('end', e.target.value)} required />
+                    </div>
+                  </div>
+                  <Button type="submit" disabled={loading} className="w-full">
+                    {loading ? 'Booking...' : 'Book Now'}
+                  </Button>
+                </form>
+              </div>
+            ) : (
+              <div className="text-center py-8 text-muted-foreground">Loading...</div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default BookVehicle;

--- a/src/pages/ManageBookings.tsx
+++ b/src/pages/ManageBookings.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useState, useCallback } from 'react';
+import { Navigate } from 'react-router-dom';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/hooks/useAuth';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Car } from 'lucide-react';
+
+interface Booking {
+  id: string;
+  vehicle_id: string;
+  customer_name: string;
+  customer_email: string;
+  start_date: string;
+  end_date: string;
+  status: string;
+  vehicles?: {
+    make: string;
+    model: string;
+    year: number;
+  } | null;
+}
+
+const ManageBookings = () => {
+  const { user } = useAuth();
+  const [bookings, setBookings] = useState<Booking[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const loadBookings = useCallback(async () => {
+    if (!user) return;
+    const { data: agency } = await supabase
+      .from('agencies')
+      .select('id')
+      .eq('user_id', user.id)
+      .single();
+    if (!agency) {
+      setLoading(false);
+      return;
+    }
+    const { data: vehicles } = await supabase
+      .from('vehicles')
+      .select('id')
+      .eq('agency_id', agency.id);
+    const ids = vehicles?.map((v) => v.id) || [];
+    if (ids.length === 0) {
+      setBookings([]);
+      setLoading(false);
+      return;
+    }
+    const { data } = await supabase
+      .from('bookings')
+      .select('id, vehicle_id, customer_name, customer_email, start_date, end_date, status, vehicles(make, model, year)')
+      .in('vehicle_id', ids)
+      .order('created_at', { ascending: false });
+    setBookings((data as Booking[]) || []);
+    setLoading(false);
+  }, [user]);
+
+  useEffect(() => {
+    loadBookings();
+  }, [loadBookings]);
+
+  if (!user) {
+    return <Navigate to="/agency-auth" replace />;
+  }
+
+  return (
+    <div className="min-h-screen bg-background p-4">
+      <div className="container">
+        <Card>
+          <CardHeader>
+            <CardTitle>Bookings</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {loading ? (
+              <div className="text-center py-8 text-muted-foreground">Loading...</div>
+            ) : bookings.length === 0 ? (
+              <div className="text-center py-8 text-muted-foreground">No bookings found.</div>
+            ) : (
+              <div className="space-y-4">
+                {bookings.map((b) => (
+                  <div key={b.id} className="border p-4 rounded-md flex justify-between items-start gap-4">
+                    <div className="flex gap-4 items-start">
+                      <Car className="h-6 w-6 text-primary" />
+                      <div>
+                        <p className="font-semibold">
+                          {b.vehicles ? `${b.vehicles.year} ${b.vehicles.make} ${b.vehicles.model}` : b.vehicle_id}
+                        </p>
+                        <p className="text-sm text-muted-foreground">
+                          {b.start_date} to {b.end_date}
+                        </p>
+                        <p className="text-sm text-muted-foreground">
+                          {b.customer_name} ({b.customer_email})
+                        </p>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm capitalize mr-2">{b.status}</span>
+                      {/* Potential actions could go here */}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default ManageBookings;

--- a/supabase/migrations/20250712120000-add-bookings-table.sql
+++ b/supabase/migrations/20250712120000-add-bookings-table.sql
@@ -1,0 +1,41 @@
+-- Create bookings table
+CREATE TABLE public.bookings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  vehicle_id UUID NOT NULL REFERENCES public.vehicles(id) ON DELETE CASCADE,
+  customer_name TEXT NOT NULL,
+  customer_email TEXT NOT NULL,
+  start_date DATE NOT NULL,
+  end_date DATE NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Enable Row Level Security
+ALTER TABLE public.bookings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public can create bookings" ON public.bookings
+FOR INSERT WITH CHECK (true);
+
+CREATE POLICY "Agency owners can view their vehicle bookings" ON public.bookings
+FOR SELECT USING (
+  vehicle_id IN (
+    SELECT id FROM public.vehicles WHERE agency_id IN (
+      SELECT id FROM public.agencies WHERE user_id = auth.uid()
+    )
+  )
+);
+
+CREATE POLICY "Agency owners can update their vehicle bookings" ON public.bookings
+FOR UPDATE USING (
+  vehicle_id IN (
+    SELECT id FROM public.vehicles WHERE agency_id IN (
+      SELECT id FROM public.agencies WHERE user_id = auth.uid()
+    )
+  )
+);
+
+CREATE TRIGGER update_bookings_updated_at
+  BEFORE UPDATE ON public.bookings
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();


### PR DESCRIPTION
## Summary
- add new Supabase migration to create `bookings` table
- extend Supabase types with bookings
- create booking page for customers
- create bookings management page for agencies
- wire routes and update featured vehicles button
- fix type warnings in vehicle editing

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6871b860c758832fbbb889ca196995dd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Book Vehicle" page allowing users to book vehicles via a form.
  * Introduced a "Manage Bookings" page for agency owners to view and manage vehicle bookings.
  * Updated vehicle cards with a "Book Now" button that links directly to the booking page.

* **Bug Fixes**
  * Improved form handling in vehicle editing dialogs for better reliability.

* **Chores**
  * Added support for vehicle booking management in the backend, including new database tables and access policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->