### PR TITLE
Enhance bookings with contact details and notifications

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -142,6 +142,8 @@ export type Database = {
           vehicle_id: string
           customer_name: string
           customer_email: string
+          phone_number: string | null
+          notes: string | null
           start_date: string
           end_date: string
           status: string
@@ -153,6 +155,8 @@ export type Database = {
           vehicle_id: string
           customer_name: string
           customer_email: string
+          phone_number?: string | null
+          notes?: string | null
           start_date: string
           end_date: string
           status?: string
@@ -164,6 +168,8 @@ export type Database = {
           vehicle_id?: string
           customer_name?: string
           customer_email?: string
+          phone_number?: string | null
+          notes?: string | null
           start_date?: string
           end_date?: string
           status?: string

--- a/src/pages/BookVehicle.tsx
+++ b/src/pages/BookVehicle.tsx
@@ -23,6 +23,8 @@ const BookVehicle = () => {
   const [form, setForm] = useState({
     name: '',
     email: '',
+    phone: '',
+    notes: '',
     start: '',
     end: ''
   });
@@ -54,6 +56,8 @@ const BookVehicle = () => {
       vehicle_id: vehicleId,
       customer_name: form.name,
       customer_email: form.email,
+      phone_number: form.phone || null,
+      notes: form.notes || null,
       start_date: form.start,
       end_date: form.end
     });
@@ -61,7 +65,7 @@ const BookVehicle = () => {
       toast({ title: 'Error', description: (error as Error).message, variant: 'destructive' });
     } else {
       toast({ title: 'Booked', description: 'Your booking was created.' });
-      setForm({ name: '', email: '', start: '', end: '' });
+      setForm({ name: '', email: '', phone: '', notes: '', start: '', end: '' });
     }
     setLoading(false);
   };
@@ -99,6 +103,14 @@ const BookVehicle = () => {
                   <div className="space-y-2">
                     <Label htmlFor="email">Email</Label>
                     <Input id="email" type="email" value={form.email} onChange={(e) => update('email', e.target.value)} required />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="phone">Phone Number</Label>
+                    <Input id="phone" value={form.phone} onChange={(e) => update('phone', e.target.value)} required />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="notes">Additional Info</Label>
+                    <Input id="notes" value={form.notes} onChange={(e) => update('notes', e.target.value)} />
                   </div>
                   <div className="grid grid-cols-2 gap-4">
                     <div className="space-y-2">

--- a/supabase/migrations/20250713120000-add-phone-notes-to-bookings.sql
+++ b/supabase/migrations/20250713120000-add-phone-notes-to-bookings.sql
@@ -1,0 +1,4 @@
+-- Add phone number and notes to bookings table
+ALTER TABLE public.bookings
+  ADD COLUMN phone_number TEXT,
+  ADD COLUMN notes TEXT;


### PR DESCRIPTION
## Summary
- extend bookings schema with phone and notes
- update supabase types
- include phone and notes on the booking form
- display phone and notes when managing bookings
- notify fleet managers in realtime for new bookings

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6871bbe543ac832f91e75e3e73f6a413

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for collecting and displaying phone number and additional notes when making a booking.
  * Booking form now includes fields for phone number (required) and additional info (optional).
  * Manage Bookings page displays phone number and notes for each booking, if available.
  * Real-time notifications are shown for new bookings.

* **Bug Fixes**
  * Removed unused button from the Manage Bookings page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->