### PR TITLE
Fix unauthorized booking error

### DIFF
--- a/src/components/FeaturedVehicles.tsx
+++ b/src/components/FeaturedVehicles.tsx
@@ -108,14 +108,15 @@ const FeaturedVehicles = () => {
                 </div>
 
                 <div className="flex gap-2">
-                  <Button
-                    asChild
-                    variant={vehicle.is_available ? "default" : "outline"}
-                    className="flex-1"
-                    disabled={!vehicle.is_available}
-                  >
-                    <Link to={`/book/${vehicle.id}`}>{vehicle.is_available ? "Book Now" : "Notify When Available"}</Link>
-                  </Button>
+                  {vehicle.is_available ? (
+                    <Button asChild variant="default" className="flex-1">
+                      <Link to={`/book/${vehicle.id}`}>Book Now</Link>
+                    </Button>
+                  ) : (
+                    <Button variant="outline" className="flex-1" disabled>
+                      Notify When Available
+                    </Button>
+                  )}
                   <Button variant="outline" size="icon">
                     <MessageCircle className="h-4 w-4" />
                   </Button>

--- a/src/pages/BookVehicle.tsx
+++ b/src/pages/BookVehicle.tsx
@@ -69,7 +69,7 @@ const BookVehicle = () => {
       return;
     }
     setLoading(true);
-    const { data: booking, error } = await supabase
+    const { error } = await supabase
       .from('bookings')
       .insert({
         vehicle_id: vehicleId,
@@ -79,9 +79,7 @@ const BookVehicle = () => {
         notes: form.notes || null,
         start_date: form.start,
         end_date: form.end,
-      })
-      .select()
-      .single();
+      });
     if (error) {
       toast({
         title: 'Error',
@@ -103,8 +101,7 @@ const BookVehicle = () => {
         await channel.subscribe();
         await channel.send({
           type: 'broadcast',
-          event: 'new-booking',
-          payload: { bookingId: booking.id },
+          event: 'new-booking'
         });
         await supabase.removeChannel(channel);
       }


### PR DESCRIPTION
## Summary
- remove select from booking insert to avoid unauthorized error
- simplify broadcast payload on booking creation

## Testing
- `npm run lint`
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_6871e2137b3c832fae4694217b4a652f