### PR TITLE
Add bookings page to owner dashboard

### DIFF
--- a/src/components/OwnerHeader.tsx
+++ b/src/components/OwnerHeader.tsx
@@ -1,0 +1,50 @@
+import { Car, Settings, LogOut } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/hooks/useAuth';
+
+interface OwnerHeaderProps {
+  page: 'dashboard' | 'bookings';
+  agencyName?: string | null;
+}
+
+const OwnerHeader = ({ page, agencyName }: OwnerHeaderProps) => {
+  const { signOut } = useAuth();
+  return (
+    <header className="border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <div className="container flex h-16 items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Car className="h-6 w-6 text-primary" />
+          <span className="text-xl font-bold">RentalHub</span>
+          <span className="text-sm text-muted-foreground ml-2 capitalize">
+            {page}
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          {agencyName && (
+            <span className="text-sm text-muted-foreground hidden sm:block">
+              {agencyName}
+            </span>
+          )}
+          {page === 'dashboard' ? (
+            <Button variant="ghost" size="sm" asChild>
+              <Link to="/manage-bookings">Bookings</Link>
+            </Button>
+          ) : (
+            <Button variant="ghost" size="sm" asChild>
+              <Link to="/dashboard">Dashboard</Link>
+            </Button>
+          )}
+          <Button variant="ghost" size="icon">
+            <Settings className="h-4 w-4" />
+          </Button>
+          <Button variant="ghost" size="icon" onClick={signOut}>
+            <LogOut className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default OwnerHeader;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Car, Plus, Settings, LogOut } from 'lucide-react';
+import { Car, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useAuth } from '@/hooks/useAuth';
@@ -7,6 +7,7 @@ import { supabase } from '@/integrations/supabase/client';
 import VehicleList, { Vehicle } from '@/components/VehicleList';
 import AddVehicleDialog from '@/components/AddVehicleDialog';
 import { Navigate } from 'react-router-dom';
+import OwnerHeader from '@/components/OwnerHeader';
 
 interface Agency {
   id: string;
@@ -15,7 +16,7 @@ interface Agency {
 }
 
 const Dashboard = () => {
-  const { user, signOut } = useAuth();
+  const { user } = useAuth();
   const [agency, setAgency] = useState<Agency | null>(null);
   const [vehicles, setVehicles] = useState<Vehicle[]>([]);
   const [showAddVehicle, setShowAddVehicle] = useState(false);
@@ -86,27 +87,7 @@ const Dashboard = () => {
   return (
     <div className="min-h-screen bg-gradient-to-br from-background via-background to-primary/5">
       {/* Header */}
-      <header className="border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-        <div className="container flex h-16 items-center justify-between">
-          <div className="flex items-center gap-2">
-            <Car className="h-6 w-6 text-primary" />
-            <span className="text-xl font-bold">RentalHub</span>
-            <span className="text-sm text-muted-foreground ml-2">Dashboard</span>
-          </div>
-          
-          <div className="flex items-center gap-3">
-            <span className="text-sm text-muted-foreground hidden sm:block">
-              {agency?.company_name}
-            </span>
-            <Button variant="ghost" size="icon">
-              <Settings className="h-4 w-4" />
-            </Button>
-            <Button variant="ghost" size="icon" onClick={signOut}>
-              <LogOut className="h-4 w-4" />
-            </Button>
-          </div>
-        </div>
-      </header>
+      <OwnerHeader page="dashboard" agencyName={agency?.company_name} />
 
       <div className="container py-8">
         {/* Welcome Section */}

--- a/src/pages/ManageBookings.tsx
+++ b/src/pages/ManageBookings.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Car } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { Button } from '@/components/ui/button';
+import OwnerHeader from '@/components/OwnerHeader';
 
 interface Booking {
   id: string;
@@ -30,6 +31,7 @@ const ManageBookings = () => {
   const [loading, setLoading] = useState(true);
   const [vehicleIds, setVehicleIds] = useState<string[]>([]);
   const [agencyId, setAgencyId] = useState<string | null>(null);
+  const [agencyName, setAgencyName] = useState<string | null>(null);
   const { toast } = useToast();
 
   const updateStatus = async (id: string, status: string) => {
@@ -53,7 +55,7 @@ const ManageBookings = () => {
     if (!user) return;
     const { data: agency } = await supabase
       .from('agencies')
-      .select('id')
+      .select('id, company_name')
       .eq('user_id', user.id)
       .single();
     if (!agency) {
@@ -61,6 +63,7 @@ const ManageBookings = () => {
       return;
     }
     setAgencyId(agency.id);
+    setAgencyName(agency.company_name);
     const { data: vehicles } = await supabase
       .from('vehicles')
       .select('id')
@@ -111,8 +114,9 @@ const ManageBookings = () => {
   }
 
   return (
-    <div className="min-h-screen bg-background p-4">
-      <div className="container">
+    <div className="min-h-screen bg-gradient-to-br from-background via-background to-primary/5">
+      <OwnerHeader page="bookings" agencyName={agencyName} />
+      <div className="container py-8">
         <Card>
           <CardHeader>
             <CardTitle>Bookings</CardTitle>


### PR DESCRIPTION
## Summary
- create an `OwnerHeader` component shared between dashboard pages
- use the new header on the main Dashboard and Manage Bookings page
- link to `/manage-bookings` from the dashboard header
- show dashboard link on the bookings page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6871fc9471fc832fa62f977c58dffe07