### PR TITLE
Add rentals management and update booking handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import AgencyAuth from "./pages/AgencyAuth";
 import Dashboard from "./pages/Dashboard";
 import BookVehicle from "./pages/BookVehicle";
 import ManageBookings from "./pages/ManageBookings";
+import CurrentRentals from "./pages/CurrentRentals";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -26,6 +27,7 @@ const App = () => (
             <Route path="/dashboard" element={<Dashboard />} />
             <Route path="/book/:vehicleId" element={<BookVehicle />} />
             <Route path="/manage-bookings" element={<ManageBookings />} />
+            <Route path="/current-rentals" element={<CurrentRentals />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/components/OwnerHeader.tsx
+++ b/src/components/OwnerHeader.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { useAuth } from '@/hooks/useAuth';
 
 interface OwnerHeaderProps {
-  page: 'dashboard' | 'bookings';
+  page: 'dashboard' | 'bookings' | 'rentals';
   agencyName?: string | null;
 }
 
@@ -26,13 +26,19 @@ const OwnerHeader = ({ page, agencyName }: OwnerHeaderProps) => {
               {agencyName}
             </span>
           )}
-          {page === 'dashboard' ? (
+          {page !== 'dashboard' && (
+            <Button variant="ghost" size="sm" asChild>
+              <Link to="/dashboard">Dashboard</Link>
+            </Button>
+          )}
+          {page !== 'bookings' && (
             <Button variant="ghost" size="sm" asChild>
               <Link to="/manage-bookings">Bookings</Link>
             </Button>
-          ) : (
+          )}
+          {page !== 'rentals' && (
             <Button variant="ghost" size="sm" asChild>
-              <Link to="/dashboard">Dashboard</Link>
+              <Link to="/current-rentals">Rentals</Link>
             </Button>
           )}
           <Button variant="ghost" size="icon">


### PR DESCRIPTION
## Summary
- delete declined bookings and lock vehicle when booking is accepted
- add a Current Rentals page to track active rentals
- update OwnerHeader navigation
- register the new route

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6872110e2538832fb7eff24289931997